### PR TITLE
Restyle product museum with retro cards

### DIFF
--- a/projectmuseum.html
+++ b/projectmuseum.html
@@ -2,260 +2,474 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>CentralSchool.fun - Product Museum</title>
   <style>
+    :root {
+      --ink: #f9fbff;
+      --bg1: #0b0130;
+      --bg2: #1a0e5a;
+      --bg3: #2a1e7a;
+      --hot: #ff68d8;
+      --aqua: #64fff2;
+      --gold: #ffd66b;
+      --lime: #9dffa8;
+      --sky: #8fc8ff;
+      --panel: #120a3c;
+      --edge: #66a2ff;
+      --card-bg: rgba(15, 9, 64, 0.88);
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
     body {
       margin: 0;
-      padding: 20px;
-      background-color: #00cccc; /* 90s teal background */
-      font-family: "Courier New", monospace;
-      color: #000;
+      min-height: 100vh;
+      padding: 32px 16px 48px;
+      color: var(--ink);
+      font-family: "Trebuchet MS", "Comic Sans MS", Verdana, Tahoma, sans-serif;
+      background:
+        radial-gradient(1200px 600px at 80% -20%, #ff58b811, transparent),
+        radial-gradient(900px 500px at -10% 110%, #64fff20e, transparent),
+        linear-gradient(var(--bg3), var(--bg1));
     }
 
-    /* Flashing Warning */
+    .page {
+      max-width: 1024px;
+      margin: 0 auto;
+      display: grid;
+      gap: 24px;
+    }
+
+    .flashing-warning {
+      animation: flash 2s steps(1, end) infinite;
+      text-align: center;
+      background: var(--hot);
+      color: #210033;
+      font-weight: 900;
+      padding: 8px 12px;
+      border: 3px dashed var(--ink);
+      border-radius: 8px;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+
     @keyframes flash {
-      0%, 50% {
+      0%, 60% {
         opacity: 1;
       }
-      50.1%, 100% {
-        opacity: 0;
+      60.01%, 100% {
+        opacity: 0.35;
       }
     }
-    .flashing-warning {
-      animation: flash 2s infinite;
+
+    header.page-header {
       text-align: center;
-      background: red;
-      color: #fff;
-      font-weight: bold;
-      padding: 5px;
-      margin: 0 0 10px 0;
-      font-size: 1.1em;
-      border: 2px dashed #000;
+      padding: 12px 18px 18px;
+      background: var(--card-bg);
+      border: 3px solid var(--edge);
+      border-radius: 16px;
+      box-shadow: 0 16px 36px rgba(0, 0, 0, 0.35);
+      backdrop-filter: blur(6px);
     }
 
-    h1 {
-      text-align: center;
-      background: #ff00ff;
-      color: #fff;
-      padding: 10px;
-      margin-bottom: 20px;
-      border: 4px dashed #000;
-      font-size: 1.8em;
+    .page-title {
+      margin: 0;
+      font-size: clamp(2rem, 4vw, 2.8rem);
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      text-shadow: 0 0 18px rgba(100, 255, 242, 0.6);
     }
-    .category {
-      margin-bottom: 30px;
+
+    .page-subtitle {
+      margin: 10px 0 0;
+      font-size: 1rem;
+      opacity: 0.86;
     }
-    .category h2 {
-      background: #ff6600;
-      color: #fff;
-      padding: 5px 10px;
-      display: inline-block;
-      border: 2px solid #000;
-      margin-bottom: 10px;
+
+    main {
+      display: grid;
+      gap: 24px;
     }
-    .banner-list {
+
+    .museum-card {
+      background: var(--card-bg);
+      border: 3px solid var(--edge);
+      border-radius: 18px;
+      box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+      padding: 22px 20px 26px;
+      display: grid;
+      gap: 18px;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .museum-card::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(135deg, #ffffff0a, transparent 55%);
+      pointer-events: none;
+    }
+
+    .museum-card header {
       display: flex;
       flex-wrap: wrap;
-      gap: 10px;
-      margin-top: 10px;
+      align-items: center;
+      gap: 12px;
+      position: relative;
+      z-index: 1;
     }
-    .banner {
+
+    .category-badge {
+      width: 58px;
+      height: 58px;
+      display: grid;
+      place-items: center;
+      border-radius: 14px;
+      border: 3px solid var(--edge);
+      background: radial-gradient(circle at 30% 30%, #fff8 0 20%, transparent 55%), var(--bg2);
+      box-shadow: 0 0 16px rgba(102, 162, 255, 0.5);
+      flex-shrink: 0;
+    }
+
+    .category-badge svg {
+      width: 34px;
+      height: 34px;
+      filter: drop-shadow(0 0 6px rgba(0, 0, 0, 0.6));
+    }
+
+    .museum-card h2 {
+      margin: 0;
+      font-size: 1.6rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    .museum-card p {
+      margin: 0;
+      font-size: 0.95rem;
+      line-height: 1.4;
+      opacity: 0.86;
+    }
+
+    .exhibit-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 12px;
+      position: relative;
+      z-index: 1;
+    }
+
+    .exhibit-card {
       display: flex;
       align-items: center;
+      gap: 14px;
+      padding: 14px 16px;
+      background: rgba(11, 1, 48, 0.8);
+      border: 2px solid transparent;
+      border-radius: 14px;
+      color: var(--ink);
       text-decoration: none;
-      color: #000;
-      background: #ffff00;
-      padding: 5px 10px;
-      border: 2px solid #000;
-      transition: all 0.2s;
+      transition: transform 0.18s ease, box-shadow 0.18s ease, border 0.18s ease;
     }
-    .banner:hover {
-      background: #ffcc00;
-      transform: scale(1.05);
+
+    .exhibit-card:hover,
+    .exhibit-card:focus-visible {
+      transform: translateY(-4px) scale(1.01);
+      box-shadow: 0 12px 20px rgba(0, 0, 0, 0.45);
+      border-color: var(--aqua);
+      outline: none;
     }
-    .banner svg {
-      width: 24px;
-      height: 24px;
-      margin-right: 8px;
-      fill: #000;
+
+    .icon-wrap {
+      flex-shrink: 0;
+      width: 48px;
+      height: 48px;
+      display: grid;
+      place-items: center;
+      background: linear-gradient(140deg, rgba(255, 214, 107, 0.1), rgba(15, 9, 64, 0.4));
+      border-radius: 12px;
+      border: 2px solid rgba(159, 215, 255, 0.4);
     }
-    .banner span {
-      font-weight: bold;
-      font-size: 0.95em;
+
+    .icon-wrap svg {
+      width: 36px;
+      height: 36px;
+    }
+
+    .exhibit-content {
+      display: grid;
+      gap: 4px;
+    }
+
+    .exhibit-title {
+      font-weight: 800;
+      letter-spacing: 0.04em;
+    }
+
+    .cta {
+      font-size: 0.8rem;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      color: var(--aqua);
+    }
+
+    @media (min-width: 720px) {
+      body {
+        padding: 48px 32px 72px;
+      }
+
+      main {
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      }
     }
   </style>
 </head>
 <body>
-
-  <!-- Flashing Warning -->
-  <div class="flashing-warning">
-    You cannot buy these products outside of Central Middle School
-  </div>
-
-  <h1>CentralSchool.fun - Product Museum</h1>
-
-  <!-- Central Avengers -->
-  <div class="category">
-    <h2>Central Avengers</h2>
-    <div class="banner-list">
-      <!-- Snack Widows -->
-      <a class="banner" href="products/snackwidows.html" target="_blank">
-        <svg viewBox="0 0 100 100">
-          <!-- Snack bag with hourglass symbol -->
-          <path d="M25,10 L75,10 L85,30 L85,90 L15,90 L15,30 Z" fill="#f4a460" stroke="#000" stroke-width="2"/>
-          <path d="M40,40 L60,60 M60,40 L40,60" stroke="#000" stroke-width="4"/>
-          <path d="M35,35 C45,45 45,55 35,65 C55,65 55,35 35,35 Z" fill="#cc0000"/>
-        </svg>
-        <span>Snack Widows</span>
-      </a>
-
-      <!-- Spice Widows -->
-      <a class="banner" href="products/spicewidows.html" target="_blank">
-        <svg viewBox="0 0 100 100">
-          <!-- Spice jar with hourglass -->
-          <path d="M35,10 L65,10 L65,30 C75,35 75,65 65,70 L65,90 L35,90 L35,70 C25,65 25,35 35,30 Z" fill="#ff7f50" stroke="#000" stroke-width="2"/>
-          <path d="M40,40 L60,60 M60,40 L40,60" stroke="#000" stroke-width="3"/>
-          <ellipse cx="50" cy="20" rx="15" ry="5" fill="#ff7f50" stroke="#000" stroke-width="1"/>
-        </svg>
-        <span>Spice Widows</span>
-      </a>
-
-      <!-- Spoofed Man's Creamy Ice -->
-      <a class="banner" href="products/creamyice.html" target="_blank">
-        <svg viewBox="0 0 100 100">
-          <!-- Ice cream cone -->
-          <path d="M30,60 L50,10 L70,60 Z" fill="#f5deb3" stroke="#000" stroke-width="2"/>
-          <path d="M30,60 L50,95 L70,60 Z" fill="#d2b48c" stroke="#000" stroke-width="2"/>
-          <circle cx="50" cy="30" r="10" fill="#fff" stroke="#000" stroke-width="1"/>
-          <circle cx="40" cy="45" r="8" fill="#ffb6c1" stroke="#000" stroke-width="1"/>
-          <circle cx="60" cy="45" r="8" fill="#add8e6" stroke="#000" stroke-width="1"/>
-        </svg>
-        <span>Spoofed Man's Creamy Ice</span>
-      </a>
+  <div class="page">
+    <div class="flashing-warning" role="alert">
+      You cannot buy these products outside of Central Middle School
     </div>
-  </div>
 
-  <!-- Central Space Program -->
-  <div class="category">
-    <h2>Central Space Program</h2>
-    <div class="banner-list">
-      <!-- Eagle Rocket -->
-      <a class="banner" href="products/eagle.html" target="_blank">
-        <svg viewBox="0 0 100 100">
-          <!-- Eagle-shaped rocket -->
-          <path d="M50,5 L65,40 L85,50 L65,60 L50,95 L35,60 L15,50 L35,40 Z" fill="#c0c0c0" stroke="#000" stroke-width="2"/>
-          <path d="M40,50 L60,50" stroke="#000" stroke-width="2"/>
-          <circle cx="50" cy="40" r="5" fill="#4169e1"/>
-          <path d="M45,70 L55,70 L55,85 L50,95 L45,85 Z" fill="#ff4500" stroke="#000" stroke-width="1"/>
-        </svg>
-        <span>Eagle Rocket</span>
-      </a>
+    <header class="page-header">
+      <h1 class="page-title">Product Museum</h1>
+      <p class="page-subtitle">Archived merch, missions, and experiments from CentralSchool.fun</p>
+    </header>
 
-      <!-- STELLER JAY ROCKET -->
-      <a class="banner" href="products/stellerjay.html" target="_blank">
-        <svg viewBox="0 0 100 100">
-          <!-- Steller Jay bird-shaped rocket -->
-          <path d="M50,10 L40,30 L30,40 L40,50 L30,90 L50,80 L70,90 L60,50 L70,40 L60,30 Z" fill="#0000cd" stroke="#000" stroke-width="2"/>
-          <path d="M40,35 L60,35" stroke="#000" stroke-width="2"/>
-          <path d="M35,45 L65,45" stroke="#000" stroke-width="2"/>
-          <path d="M45,80 L55,80 L55,90 L50,95 L45,90 Z" fill="#ff4500" stroke="#000" stroke-width="1"/>
-          <path d="M45,20 L55,20 L60,10 L40,10 Z" fill="#000"/>
-        </svg>
-        <span>Steller Jay Rocket</span>
-      </a>
+    <main>
+      <section class="museum-card">
+        <header>
+          <div class="category-badge" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="var(--hot)">
+              <path d="M12 2l3 4 5 1-3 4 1 5-4-2-4 2 1-5-3-4 5-1z"/>
+            </svg>
+          </div>
+          <div>
+            <h2>Central Avengers</h2>
+            <p>Snack-fueled heroes and seasonings that saved homeroom.</p>
+          </div>
+        </header>
+        <ul class="exhibit-list">
+          <li>
+            <a class="exhibit-card" href="products/snackwidows.html" target="_blank">
+              <span class="icon-wrap">
+                <svg viewBox="0 0 100 100" aria-hidden="true">
+                  <path d="M25,10 L75,10 L85,30 L85,90 L15,90 L15,30 Z" fill="#f4a460" stroke="#000" stroke-width="2"/>
+                  <path d="M40,40 L60,60 M60,40 L40,60" stroke="#000" stroke-width="4"/>
+                  <path d="M35,35 C45,45 45,55 35,65 C55,65 55,35 35,35 Z" fill="#cc0000"/>
+                </svg>
+              </span>
+              <span class="exhibit-content">
+                <span class="exhibit-title">Snack Widows</span>
+                <span class="cta">Open exhibit</span>
+              </span>
+            </a>
+          </li>
+          <li>
+            <a class="exhibit-card" href="products/spicewidows.html" target="_blank">
+              <span class="icon-wrap">
+                <svg viewBox="0 0 100 100" aria-hidden="true">
+                  <path d="M35,10 L65,10 L65,30 C75,35 75,65 65,70 L65,90 L35,90 L35,70 C25,65 25,35 35,30 Z" fill="#ff7f50" stroke="#000" stroke-width="2"/>
+                  <path d="M40,40 L60,60 M60,40 L40,60" stroke="#000" stroke-width="3"/>
+                  <ellipse cx="50" cy="20" rx="15" ry="5" fill="#ff7f50" stroke="#000" stroke-width="1"/>
+                </svg>
+              </span>
+              <span class="exhibit-content">
+                <span class="exhibit-title">Spice Widows</span>
+                <span class="cta">Open exhibit</span>
+              </span>
+            </a>
+          </li>
+          <li>
+            <a class="exhibit-card" href="products/creamyice.html" target="_blank">
+              <span class="icon-wrap">
+                <svg viewBox="0 0 100 100" aria-hidden="true">
+                  <path d="M30,60 L50,10 L70,60 Z" fill="#f5deb3" stroke="#000" stroke-width="2"/>
+                  <path d="M30,60 L50,95 L70,60 Z" fill="#d2b48c" stroke="#000" stroke-width="2"/>
+                  <circle cx="50" cy="30" r="10" fill="#fff" stroke="#000" stroke-width="1"/>
+                  <circle cx="40" cy="45" r="8" fill="#ffb6c1" stroke="#000" stroke-width="1"/>
+                  <circle cx="60" cy="45" r="8" fill="#add8e6" stroke="#000" stroke-width="1"/>
+                </svg>
+              </span>
+              <span class="exhibit-content">
+                <span class="exhibit-title">Spoofed Man's Creamy Ice</span>
+                <span class="cta">Open exhibit</span>
+              </span>
+            </a>
+          </li>
+        </ul>
+      </section>
 
-      <!-- Big Fat Rocket -->
-      <a class="banner" href="products/bfr.html" target="_blank">
-        <svg viewBox="0 0 100 100">
-          <!-- Big wide rocket -->
-          <path d="M30,20 C30,10 70,10 70,20 L70,70 C70,80 30,80 30,70 Z" fill="#d3d3d3" stroke="#000" stroke-width="2"/>
-          <rect x="30" y="70" width="40" height="10" fill="#a9a9a9" stroke="#000" stroke-width="1"/>
-          <path d="M35,80 L45,80 L45,90 L40,95 L35,90 Z" fill="#ff4500" stroke="#000" stroke-width="1"/>
-          <path d="M55,80 L65,80 L65,90 L60,95 L55,90 Z" fill="#ff4500" stroke="#000" stroke-width="1"/>
-          <rect x="45" y="30" width="10" height="20" fill="#1e90ff" stroke="#000" stroke-width="1"/>
-        </svg>
-        <span>Big Fat Rocket</span>
-      </a>
+      <section class="museum-card">
+        <header>
+          <div class="category-badge" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="var(--aqua)">
+              <path d="M12 2l4 8-4 12-4-12z"/>
+            </svg>
+          </div>
+          <div>
+            <h2>Central Space Program</h2>
+            <p>Exploration-grade rockets with questionable trajectory guarantees.</p>
+          </div>
+        </header>
+        <ul class="exhibit-list">
+          <li>
+            <a class="exhibit-card" href="products/eagle.html" target="_blank">
+              <span class="icon-wrap">
+                <svg viewBox="0 0 100 100" aria-hidden="true">
+                  <path d="M50,5 L65,40 L85,50 L65,60 L50,95 L35,60 L15,50 L35,40 Z" fill="#c0c0c0" stroke="#000" stroke-width="2"/>
+                  <path d="M40,50 L60,50" stroke="#000" stroke-width="2"/>
+                  <circle cx="50" cy="40" r="5" fill="#4169e1"/>
+                  <path d="M45,70 L55,70 L55,85 L50,95 L45,85 Z" fill="#ff4500" stroke="#000" stroke-width="1"/>
+                </svg>
+              </span>
+              <span class="exhibit-content">
+                <span class="exhibit-title">Eagle Rocket</span>
+                <span class="cta">Launch archive</span>
+              </span>
+            </a>
+          </li>
+          <li>
+            <a class="exhibit-card" href="products/stellerjay.html" target="_blank">
+              <span class="icon-wrap">
+                <svg viewBox="0 0 100 100" aria-hidden="true">
+                  <path d="M50,10 L40,30 L30,40 L40,50 L30,90 L50,80 L70,90 L60,50 L70,40 L60,30 Z" fill="#0000cd" stroke="#000" stroke-width="2"/>
+                  <path d="M40,35 L60,35" stroke="#000" stroke-width="2"/>
+                  <path d="M35,45 L65,45" stroke="#000" stroke-width="2"/>
+                  <path d="M45,80 L55,80 L55,90 L50,95 L45,90 Z" fill="#ff4500" stroke="#000" stroke-width="1"/>
+                  <path d="M45,20 L55,20 L60,10 L40,10 Z" fill="#000"/>
+                </svg>
+              </span>
+              <span class="exhibit-content">
+                <span class="exhibit-title">Steller Jay Rocket</span>
+                <span class="cta">Launch archive</span>
+              </span>
+            </a>
+          </li>
+          <li>
+            <a class="exhibit-card" href="products/bfr.html" target="_blank">
+              <span class="icon-wrap">
+                <svg viewBox="0 0 100 100" aria-hidden="true">
+                  <path d="M30,20 C30,10 70,10 70,20 L70,70 C70,80 30,80 30,70 Z" fill="#d3d3d3" stroke="#000" stroke-width="2"/>
+                  <rect x="30" y="70" width="40" height="10" fill="#a9a9a9" stroke="#000" stroke-width="1"/>
+                  <path d="M35,80 L45,80 L45,90 L40,95 L35,90 Z" fill="#ff4500" stroke="#000" stroke-width="1"/>
+                  <path d="M55,80 L65,80 L65,90 L60,95 L55,90 Z" fill="#ff4500" stroke="#000" stroke-width="1"/>
+                  <rect x="45" y="30" width="10" height="20" fill="#1e90ff" stroke="#000" stroke-width="1"/>
+                </svg>
+              </span>
+              <span class="exhibit-content">
+                <span class="exhibit-title">Big Fat Rocket</span>
+                <span class="cta">Launch archive</span>
+              </span>
+            </a>
+          </li>
+          <li>
+            <a class="exhibit-card" href="products/rideshare.html" target="_blank">
+              <span class="icon-wrap">
+                <svg viewBox="0 0 100 100" aria-hidden="true">
+                  <path d="M30,30 L70,30 C80,50 80,70 70,80 L30,80 C20,70 20,50 30,30 Z" fill="#f5f5f5" stroke="#000" stroke-width="2"/>
+                  <circle cx="35" cy="45" r="5" fill="#ff69b4"/>
+                  <circle cx="50" cy="45" r="5" fill="#32cd32"/>
+                  <circle cx="65" cy="45" r="5" fill="#1e90ff"/>
+                  <path d="M40,80 L40,90 L60,90 L60,80" fill="none" stroke="#000" stroke-width="2"/>
+                  <path d="M30,30 L40,10 L60,10 L70,30" fill="#f5f5f5" stroke="#000" stroke-width="2"/>
+                </svg>
+              </span>
+              <span class="exhibit-content">
+                <span class="exhibit-title">SpaceY Rideshare</span>
+                <span class="cta">Launch archive</span>
+              </span>
+            </a>
+          </li>
+        </ul>
+      </section>
 
-      <!-- SpaceY Rideshare -->
-      <a class="banner" href="products/rideshare.html" target="_blank">
-        <svg viewBox="0 0 100 100">
-          <!-- Capsule with passengers -->
-          <path d="M30,30 L70,30 C80,50 80,70 70,80 L30,80 C20,70 20,50 30,30 Z" fill="#f5f5f5" stroke="#000" stroke-width="2"/>
-          <circle cx="35" cy="45" r="5" fill="#ff69b4"/>
-          <circle cx="50" cy="45" r="5" fill="#32cd32"/>
-          <circle cx="65" cy="45" r="5" fill="#1e90ff"/>
-          <path d="M40,80 L40,90 L60,90 L60,80" fill="none" stroke="#000" stroke-width="2"/>
-          <path d="M30,30 L40,10 L60,10 L70,30" fill="#f5f5f5" stroke="#000" stroke-width="2"/>
-        </svg>
-        <span>SpaceY Rideshare</span>
-      </a>
-    </div>
-  </div>
-
-  <!-- Other -->
-  <div class="category">
-    <h2>Other</h2>
-    <div class="banner-list">
-      <!-- Otter 1A engine -->
-      
-
-     
-
-      <!-- Central Tlks -->
-      <a class="banner" href="https://cmstlks.masto.host" target="_blank">
-        <svg viewBox="0 0 100 100">
-          <!-- Microphone with speech bubble -->
-          <path d="M50,20 L80,20 L80,60 L60,60 L50,75 L50,60 L20,60 L20,20 Z" fill="#fff" stroke="#000" stroke-width="2"/>
-          <rect x="40" y="75" width="20" height="15" rx="5" ry="5" fill="#444" stroke="#000" stroke-width="1"/>
-          <rect x="45" y="65" width="10" height="15" fill="#666" stroke="#000" stroke-width="1"/>
-          <path d="M30,35 L70,35 M30,45 L70,45" stroke="#000" stroke-width="1" stroke-dasharray="2,2"/>
-        </svg>
-        <span>Central Tlks</span>
-      </a>
-
-      <!-- Minions -->
-      <a class="banner" href="products/minion.html" target="_blank">
-        <svg viewBox="0 0 100 100">
-          <!-- Yellow minion character -->
-          <ellipse cx="50" cy="55" rx="25" ry="35" fill="#ffff00" stroke="#000" stroke-width="2"/>
-          <circle cx="50" cy="40" r="15" fill="#fff" stroke="#000" stroke-width="2"/>
-          <circle cx="50" cy="40" r="8" fill="#4b5320" stroke="#000" stroke-width="1"/>
-          <circle cx="50" cy="40" r="3" fill="#000"/>
-          <rect x="40" y="70" width="20" height="15" fill="#0077be" stroke="#000" stroke-width="2"/>
-          <path d="M30,50 L20,60 M70,50 L80,60" stroke="#000" stroke-width="2"/>
-        </svg>
-        <span>Minions</span>
-      </a>
-
-      <!-- RizzGPT -->
-      <a class="banner" href="products/rizzgpt.html" target="_blank">
-        <svg viewBox="0 0 100 100">
-          <!-- Chat AI with hearts -->
-          <rect x="20" y="20" width="60" height="60" rx="10" ry="10" fill="#f0f0f0" stroke="#000" stroke-width="2"/>
-          <path d="M30,35 L70,35 M30,50 L70,50 M30,65 L50,65" stroke="#000" stroke-width="2"/>
-          <path d="M35,25 C25,40 45,45 35,35" fill="#ff69b4" stroke="#000" stroke-width="1"/>
-          <path d="M65,25 C55,40 75,45 65,35" fill="#ff69b4" stroke="#000" stroke-width="1"/>
-          <path d="M65,80 L80,95 L50,95" fill="#f0f0f0" stroke="#000" stroke-width="2"/>
-        </svg>
-        <span>RizzGPT</span>
-      </a>
-
-            <!-- Sales Chat -->
-      <a class="banner" href="https://salexai-elon.hf.space/" target="_blank">
-        <svg viewBox="0 0 100 100">
-          <!-- Chat bubble with a lightning bolt -->
-          <path d="M10,20 Q10,10 20,10 L80,10 Q90,10 90,20 L90,60 Q90,70 80,70 L30,70 L10,90 Z" fill="#f0f0f0" stroke="#000" stroke-width="2"/>
-          <path d="M45,25 L55,25 L50,40 L60,40 L45,65 L50,50 L40,50 Z" fill="#ffcc00" stroke="#000" stroke-width="1"/>
-        </svg>
-        <span>Talk to Elon Ma</span>
-
-
-
-      </a>
-    </div>
-  </div>
- </div>
+      <section class="museum-card">
+        <header>
+          <div class="category-badge" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="var(--gold)">
+              <path d="M4 4h16l-2 12H6z"/>
+            </svg>
+          </div>
+          <div>
+            <h2>Other Exhibits</h2>
+            <p>Assorted experiments, beta chats, and merch adjacent oddities.</p>
+          </div>
+        </header>
+        <ul class="exhibit-list">
+          <li>
+            <a class="exhibit-card" href="https://cmstlks.masto.host" target="_blank">
+              <span class="icon-wrap">
+                <svg viewBox="0 0 100 100" aria-hidden="true">
+                  <path d="M50,20 L80,20 L80,60 L60,60 L50,75 L50,60 L20,60 L20,20 Z" fill="#fff" stroke="#000" stroke-width="2"/>
+                  <rect x="40" y="75" width="20" height="15" rx="5" ry="5" fill="#444" stroke="#000" stroke-width="1"/>
+                  <rect x="45" y="65" width="10" height="15" fill="#666" stroke="#000" stroke-width="1"/>
+                  <path d="M30,35 L70,35 M30,45 L70,45" stroke="#000" stroke-width="1" stroke-dasharray="2,2"/>
+                </svg>
+              </span>
+              <span class="exhibit-content">
+                <span class="exhibit-title">Central Tlks</span>
+                <span class="cta">Join the chatter</span>
+              </span>
+            </a>
+          </li>
+          <li>
+            <a class="exhibit-card" href="products/minion.html" target="_blank">
+              <span class="icon-wrap">
+                <svg viewBox="0 0 100 100" aria-hidden="true">
+                  <ellipse cx="50" cy="55" rx="25" ry="35" fill="#ffff00" stroke="#000" stroke-width="2"/>
+                  <circle cx="50" cy="40" r="15" fill="#fff" stroke="#000" stroke-width="2"/>
+                  <circle cx="50" cy="40" r="8" fill="#4b5320" stroke="#000" stroke-width="1"/>
+                  <circle cx="50" cy="40" r="3" fill="#000"/>
+                  <rect x="40" y="70" width="20" height="15" fill="#0077be" stroke="#000" stroke-width="2"/>
+                  <path d="M30,50 L20,60 M70,50 L80,60" stroke="#000" stroke-width="2"/>
+                </svg>
+              </span>
+              <span class="exhibit-content">
+                <span class="exhibit-title">Minions</span>
+                <span class="cta">View dossier</span>
+              </span>
+            </a>
+          </li>
+          <li>
+            <a class="exhibit-card" href="products/rizzgpt.html" target="_blank">
+              <span class="icon-wrap">
+                <svg viewBox="0 0 100 100" aria-hidden="true">
+                  <rect x="20" y="20" width="60" height="60" rx="10" ry="10" fill="#f0f0f0" stroke="#000" stroke-width="2"/>
+                  <path d="M30,35 L70,35 M30,50 L70,50 M30,65 L50,65" stroke="#000" stroke-width="2"/>
+                  <path d="M35,25 C25,40 45,45 35,35" fill="#ff69b4" stroke="#000" stroke-width="1"/>
+                  <path d="M65,25 C55,40 75,45 65,35" fill="#ff69b4" stroke="#000" stroke-width="1"/>
+                  <path d="M65,80 L80,95 L50,95" fill="#f0f0f0" stroke="#000" stroke-width="2"/>
+                </svg>
+              </span>
+              <span class="exhibit-content">
+                <span class="exhibit-title">RizzGPT</span>
+                <span class="cta">View dossier</span>
+              </span>
+            </a>
+          </li>
+          <li>
+            <a class="exhibit-card" href="https://salexai-elon.hf.space/" target="_blank">
+              <span class="icon-wrap">
+                <svg viewBox="0 0 100 100" aria-hidden="true">
+                  <path d="M10,20 Q10,10 20,10 L80,10 Q90,10 90,20 L90,60 Q90,70 80,70 L30,70 L10,90 Z" fill="#f0f0f0" stroke="#000" stroke-width="2"/>
+                  <path d="M45,25 L55,25 L50,40 L60,40 L45,65 L50,50 L40,50 Z" fill="#ffcc00" stroke="#000" stroke-width="1"/>
+                </svg>
+              </span>
+              <span class="exhibit-content">
+                <span class="exhibit-title">Talk to Elon Ma</span>
+                <span class="cta">Launch chat</span>
+              </span>
+            </a>
+          </li>
+        </ul>
+      </section>
+    </main>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the museum page styling with a neon 90s theme that reuses the home page palette
- reorganize the exhibit listings into retro card components with consistent badges, descriptions, and CTAs
- clean up the markup structure so the alert, header, and sections sit within a dedicated page container

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e1e0e6fd4083219a806bc6a1205746