### PR TITLE
Load videos in parallel and show outage banner

### DIFF
--- a/ImageGen.html
+++ b/ImageGen.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Images.Fun</title>
+  <style>
+    html, body {
+      height: 100%;
+      margin: 0;
+      background: #04010f;
+      overflow: hidden;
+    }
+    iframe {
+      border: 0;
+      width: 100%;
+      height: 100%;
+    }
+  </style>
+</head>
+<body>
+  <iframe
+    src="https://images-fun-446778277069.us-west1.run.app"
+    title="Images.Fun Generator"
+    allow="camera; microphone"
+  ></iframe>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -163,7 +163,16 @@
         <div class="st-desc">Clips, mixes, and bloopers that made the cut.</div>
       </a>
 
-      <a class="sticker" href="progamerden.html" style="--i:4; --rot:-1deg">
+      <a class="sticker" href="ImageGen.html" style="--i:4; --rot:-1.4deg">
+        <span class="tag fun">FUN</span>
+        <div class="st-title">
+          <svg viewBox="0 0 24 24" fill="#ffd66b"><rect x="4" y="4" width="16" height="16" rx="3"/><circle cx="12" cy="12" r="4" fill="#051227"/></svg>
+          Images.Fun
+        </div>
+        <div class="st-desc">Generate AI art starring your favorite teachers.</div>
+      </a>
+
+      <a class="sticker" href="progamerden.html" style="--i:5; --rot:-1deg">
         <span class="tag wip">GAMES!!!</span>
         <div class="st-title">
           <svg viewBox="0 0 24 24" fill="#ff68d8"><rect x="3" y="10" width="18" height="6" rx="3"/><circle cx="9" cy="13" r="1.2" fill="#051227"/><circle cx="15" cy="13" r="1.2" fill="#051227"/></svg>
@@ -172,7 +181,7 @@
         <div class="st-desc">Games that I stole from other ppl on scratch... And Skibidi Slicers!</div>
       </a>
 
-      <a class="sticker" href="thecentraltimes.html" style="--i:5; --rot:1.2deg">
+      <a class="sticker" href="thecentraltimes.html" style="--i:6; --rot:1.2deg">
         <span class="tag">NEWS</span>
         <div class="st-title">
           <svg viewBox="0 0 24 24" fill="#ffd66b"><rect x="3" y="4" width="8" height="14" fill="#fff"/><rect x="13" y="4" width="8" height="14" fill="#fff"/><rect x="11" y="4" width="2" height="14" fill="#c9c9c9"/></svg>
@@ -181,7 +190,7 @@
         <div class="st-desc">News-ish. Opinions optional.</div>
       </a>
 
-      <a class="sticker" href="tlks.html" style="--i:6; --rot:-3deg">
+      <a class="sticker" href="tlks.html" style="--i:7; --rot:-3deg">
         <span class="tag weird">Preview</span>
         <div class="st-title">
           <svg viewBox="0 0 24 24" fill="#ff8a8a"><rect x="5" y="6" width="14" height="10" rx="2"/></svg>
@@ -190,7 +199,7 @@
         <div class="st-desc">Central Tlks is a group chat for the entire school! It's currently in beta. Report bugs to Alex or Cole</div>
       </a>
 
-      <a class="sticker" href="#" id="openMore" style="--i:7; --rot:2.4deg">
+      <a class="sticker" href="#" id="openMore" style="--i:8; --rot:2.4deg">
         <span class="tag">MORE</span>
         <div class="st-title">
           <svg viewBox="0 0 24 24" fill="#8fc8ff"><circle cx="6" cy="6" r="2"/><circle cx="18" cy="6" r="2"/><circle cx="6" cy="18" r="2"/><circle cx="18" cy="18" r="2"/></svg>

--- a/videocave.html
+++ b/videocave.html
@@ -524,6 +524,24 @@ body, header {
       from { transform: translateY(-20px); opacity: 0; }
       to { transform: translateY(0); opacity: 1; }
     }
+
+    .status-banner {
+      display: none;
+      margin: 12px auto 0;
+      padding: 12px 18px;
+      max-width: 600px;
+      color: #fff;
+      font-weight: bold;
+      border-radius: 14px;
+      background: linear-gradient(90deg, #ff1744, #ff9100);
+      box-shadow: 0 0 18px rgba(255, 68, 68, 0.6);
+      text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.6);
+      animation: fadeIn 0.4s ease;
+    }
+
+    .status-banner.visible {
+      display: block;
+    }
 #toast {
   opacity: 0;
   transition: opacity 0.6s ease;
@@ -560,6 +578,8 @@ body, header {
   <div class="logo">CCP</div>
   <div class="subtext">(Central Content Pool)</div>
   <div class="fineprint">(Not Communist!)</div>
+
+  <div id="hf-status" class="status-banner"></div>
 
   <div class="container">
     <!-- Search + Lucky -->
@@ -667,6 +687,17 @@ const searchInput = document.getElementById('search-input');
 const categoryBar = document.getElementById('category-bar');
 const totalCount = document.getElementById('total-count');
 const commentsWindow = document.getElementById("comments-window");
+const hfStatusBanner = document.getElementById('hf-status');
+
+function setContentPoolStatus(isDown) {
+  if (!hfStatusBanner) return;
+  if (isDown) {
+    hfStatusBanner.textContent = "Content Pool is down. Please try again later.";
+    hfStatusBanner.classList.add('visible');
+  } else {
+    hfStatusBanner.classList.remove('visible');
+  }
+}
 
 
 // =======================
@@ -788,41 +819,65 @@ async function fetchAllCategories() {
 
   // Reset General so it builds fresh
   allVideosByCategory = {};
+  setContentPoolStatus(false);
 
-  const fetchAlbum = async (cat, album) => {
-    try {
-      const res = await fetch(`https://salexai-funserver-2-0.hf.space/album/${album}`);
-      const data = await res.json();
-      allVideosByCategory[cat] = data.videos || [];
-
-      // Update General immediately
-      rebuildGeneral();
-
-      // Update running total (skip General & Cole Content Crate)
-      if (cat !== "General" && cat !== "Cole Content Crate") {
-        const prev = total;
-        total += (data.videos || []).length;
-        animateCounter(totalCount, prev, total, 600); // animate from old total → new
-      }
-    } catch {
-      showErrorToast(cat, album);
+  const fetchAlbumData = async (cat, album) => {
+    const res = await fetch(`https://salexai-funserver-2-0.hf.space/album/${album}`);
+    if (!res.ok) {
+      throw new Error(`HF Space responded with ${res.status}`);
     }
+    const data = await res.json();
+    return data.videos || [];
   };
 
-  // Instead of Promise.all, loop sequentially (or you could do Promise.allSettled for parallel)
-  for (const [cat, { album }] of Object.entries(categories)) {
-    await fetchAlbum(cat, album);
-  }
+  const categoryEntries = Object.entries(categories);
+  const results = await Promise.all(
+    categoryEntries.map(([cat, { album }]) =>
+      fetchAlbumData(cat, album)
+        .then(videos => {
+          allVideosByCategory[cat] = videos;
 
-  preloadMusic();
+          if (cat !== "General" && cat !== "Cole Content Crate") {
+            const prev = total;
+            total += videos.length;
+            animateCounter(totalCount, prev, total, 600);
+          }
+
+          return { cat, success: true };
+        })
+        .catch(error => {
+          allVideosByCategory[cat] = allVideosByCategory[cat] || [];
+          showErrorToast(cat, album);
+          return { cat, success: false, error };
+        })
+    )
+  );
+
+  rebuildGeneral();
+
+  const allFailed = results.every(result => !result.success);
 
   if (soundsEnabled) {
     sounds.loading.pause();
     sounds.loading.currentTime = 0;
-    sounds.success.play();
+    if (allFailed) {
+      sounds.error.play();
+    } else {
+      sounds.success.play();
+    }
   }
 
   hideLoadingToast();
+
+  if (allFailed) {
+    setContentPoolStatus(true);
+    toastify("Content Pool is down. Please try again later.", "error", { duration: 6000 });
+    return;
+  }
+
+  setContentPoolStatus(false);
+  preloadMusic();
+
   Toastify({
     text: "All videos loaded ✅",
     duration: 3000,
@@ -843,6 +898,7 @@ async function retryFetchCategory(cat, album, _toastElIgnored) {
     if (currentCategory === cat) renderVideos(allVideosByCategory[cat]);
 
     if (soundsEnabled) sounds.success.play();
+    setContentPoolStatus(false);
     toastify(`${cat} loaded`, "success");
   } catch {
     showErrorToast(cat, album);


### PR DESCRIPTION
## Summary
- add an outage banner element to highlight when the Hugging Face space is unavailable
- load all category albums in parallel and show a down message when every request fails
- keep the banner cleared again after successful retries and preserve existing success feedback

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f98c693e608321abd33eea3194bc69