### PR TITLE
Add AirShip listing to GamerDen catalog

### DIFF
--- a/gamerden-games.json
+++ b/gamerden-games.json
@@ -163,5 +163,16 @@
     "isNew": true,
     "launcher": "game-launcher.html",
     "content": "EA GAME GO BRRRRRRRR (1) (1).html"
+  },
+  {
+    "id": "airship-dont-hit-da-kidz",
+    "title": "AirShip: Don't Hit Da Kidz",
+    "subtitle": "By Central Students",
+    "description": "Fly the RC AirShip across the field and keep it from crashing into anyone.",
+    "icon": "🛩️",
+    "color": "#5bc0de",
+    "isNew": true,
+    "launcher": "game-launcher.html",
+    "content": "airshipgame.html"
   }
 ]


### PR DESCRIPTION
## Summary
- add the new AirShip: Don't Hit Da Kidz listing to `gamerden-games.json`
- link the entry to `airshipgame.html` with appropriate metadata so it appears in the launcher

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917ecba4d9c83218d08d590faff59ee)