### PR TITLE
Add Flying Gorilla to GamerDen

### DIFF
--- a/flying-kong.html
+++ b/flying-kong.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Flying Gorilla</title>
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      width: 100%;
+      height: 100%;
+      background: #0b0f1a;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      overflow: hidden;
+      color: #e9f3ff;
+      font-family: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+    }
+    .frame {
+      border: 2px solid #6bc1ff;
+      border-radius: 14px;
+      box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
+      width: min(1200px, 98vw);
+      height: min(720px, 92vh);
+      overflow: hidden;
+      background: #02040a;
+    }
+    iframe {
+      width: 100%;
+      height: 100%;
+      border: none;
+    }
+  </style>
+</head>
+<body>
+  <div class="frame">
+    <iframe
+      src="https://yoplay.io/flying-kong.embed"
+      title="Flying Gorilla"
+      allowfullscreen
+      scrolling="no"
+      loading="lazy">
+    </iframe>
+  </div>
+</body>
+</html>

--- a/gamerden-games.json
+++ b/gamerden-games.json
@@ -165,6 +165,17 @@
     "content": "crazy-cattle-3d.html"
   },
   {
+    "id": "flying-gorilla",
+    "title": "Flying Gorilla",
+    "subtitle": "From Yoplay",
+    "description": "Dodge pillars and soar as the most aerodynamic gorilla in town.",
+    "icon": "🦍",
+    "color": "#ff9ed6",
+    "isNew": true,
+    "launcher": "game-launcher.html",
+    "content": "flying-kong.html"
+  },
+  {
     "id": "ea-hiring-game",
     "title": "Mr Shortreed's EA Hiring Game",
     "subtitle": "By ???",


### PR DESCRIPTION
## Summary
- add a new Flying Gorilla embed page that loads the Yoplay version of the game
- register the Flying Gorilla cabinet in the GamerDen data so it appears in the launcher

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920dfb95ce883218bf0146c4f0ba618)