### PR TITLE
Add RizzGPT link to stickerboard home

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,12 +194,21 @@
         <span class="tag weird">Preview</span>
         <div class="st-title">
           <svg viewBox="0 0 24 24" fill="#ff8a8a"><rect x="5" y="6" width="14" height="10" rx="2"/></svg>
-          CentralTlks 
+          CentralTlks
         </div>
         <div class="st-desc">Central Tlks is a group chat for the entire school! It's currently in beta. Report bugs to Alex or Cole</div>
       </a>
 
-      <a class="sticker" href="#" id="openMore" style="--i:8; --rot:2.4deg">
+      <a class="sticker" href="https://rizzgpt-446778277069.us-west1.run.app/" style="--i:8; --rot:1.8deg">
+        <span class="tag">NEW</span>
+        <div class="st-title">
+          <svg viewBox="0 0 24 24" fill="#9dffa8"><circle cx="12" cy="8" r="4"/><path d="M8 16c1.5-2 6.5-2 8 0" stroke="#051227" stroke-width="1.5" fill="none" stroke-linecap="round"/></svg>
+          Talk to RizzGPT
+        </div>
+        <div class="st-desc">Chat with RizzGPT for pickup lines, advice, and more.</div>
+      </a>
+
+      <a class="sticker" href="#" id="openMore" style="--i:9; --rot:2.4deg">
         <span class="tag">MORE</span>
         <div class="st-title">
           <svg viewBox="0 0 24 24" fill="#8fc8ff"><circle cx="6" cy="6" r="2"/><circle cx="18" cy="6" r="2"/><circle cx="6" cy="18" r="2"/><circle cx="18" cy="18" r="2"/></svg>


### PR DESCRIPTION
## Summary
- add a stickerboard tile that links to the RizzGPT chat site
- adjust sticker ordering so the More tile follows the new option

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e503e61708321953ee0050fdbd556)