### PR TITLE
Add Music.Fun embed pages and navigation links

### DIFF
--- a/MusicGen.html
+++ b/MusicGen.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Music.Fun</title>
+  <style>
+    html, body {
+      height: 100%;
+      margin: 0;
+      background: #04010f;
+      overflow: hidden;
+    }
+    iframe {
+      border: 0;
+      width: 100%;
+      height: 100%;
+    }
+  </style>
+</head>
+<body>
+  <iframe
+    src="https://music-fun-1067129780637.us-west1.run.app/"
+    title="Music.Fun Generator"
+    allow="camera; microphone"
+  ></iframe>
+</body>
+</html>

--- a/app/musicfun.html
+++ b/app/musicfun.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <title>Music.Fun</title>
+
+  <style>
+    :root{
+      --safe-top: env(safe-area-inset-top, 0px);
+      --safe-right: env(safe-area-inset-right, 0px);
+    }
+
+    html, body {
+      height: 100%;
+      margin: 0;
+      background: #04010f;
+      overflow: hidden;
+    }
+
+    iframe {
+      border: 0;
+      width: 100%;
+      height: 100%;
+      display: block;
+    }
+
+    .exit-btn {
+      position: fixed;
+      top: calc(12px + var(--safe-top));
+      right: calc(12px + var(--safe-right));
+      z-index: 9999;
+
+      background: #ff3b3b;
+      color: #fff;
+      border: 2px solid #fff;
+      border-radius: 6px;
+
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+      font-size: 14px;
+      font-weight: bold;
+
+      padding: 8px 12px;
+      cursor: pointer;
+
+      box-shadow: 0 4px 0 #000;
+      touch-action: manipulation;
+    }
+
+    .exit-btn:active {
+      transform: translateY(2px);
+      box-shadow: 0 2px 0 #000;
+    }
+  </style>
+</head>
+
+<body>
+  <button class="exit-btn" id="exitBtn">EXIT ✖</button>
+
+  <iframe
+    src="https://music-fun-1067129780637.us-west1.run.app/"
+    title="Music.Fun Generator"
+    allow="camera; microphone"
+  ></iframe>
+
+  <script>
+    const exitBtn = document.getElementById("exitBtn");
+
+    function sendExit(){
+      try {
+        window.parent.postMessage("exit", "*");
+      } catch (e) {
+        console.warn("Failed to send exit message:", e);
+      }
+    }
+
+    exitBtn.addEventListener("click", sendExit);
+
+    window.addEventListener("keydown", (e) => {
+      if (e.key === "Escape") sendExit();
+    });
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -327,6 +327,15 @@
       <div class="st-desc">Generate art starring your favorite teachers.</div>
     </a>
 
+    <a class="sticker" href="MusicGen.html" id="st_music_fun">
+      <div class="st-header">
+        <div class="st-icon"><svg viewBox="0 0 24 24" fill="#ff8a8a"><path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z"/></svg></div>
+        <span class="tag fun">AI</span>
+      </div>
+      <h3 class="st-title">Music.Fun</h3>
+      <div class="st-desc">Generate songs from prompts in seconds.</div>
+    </a>
+
     <a class="sticker" href="progamerden.html" id="st_games">
       <div class="st-header">
         <div class="st-icon"><svg viewBox="0 0 24 24" fill="var(--accent)"><rect x="2" y="6" width="20" height="12" rx="3"/></svg></div>

--- a/public.html
+++ b/public.html
@@ -134,6 +134,11 @@
       <div class="label">Images.Fun</div>
     </a>
 
+    <a class="app" href="https://centralschool.fun/MusicGen.html">
+      <div class="icon games">🎵</div>
+      <div class="label">Music.Fun</div>
+    </a>
+
     <a class="app" href="https://centralschool.fun/cards.html">
       <div class="icon cards">🃏</div>
       <div class="label">TradingCards</div>


### PR DESCRIPTION
### Motivation
- Provide a Music.Fun embed page that mirrors the Images.Fun layout so the music generator can be launched from the site.
- Expose Music.Fun from both the main hub and the public app grid so users can discover and open the tool easily.

### Description
- Added `MusicGen.html` which embeds the Music.Fun app at `https://music-fun-1067129780637.us-west1.run.app/` using the same full-page iframe pattern as `ImageGen.html`.
- Added `app/musicfun.html` which matches the `app/imagefun.html` wrapper including the EXIT button and `postMessage("exit")` behavior for the embed container.
- Updated `index.html` to add a Music.Fun sticker card linking to `MusicGen.html` so the app is reachable from the main hub.
- Updated `public.html` to add a Music.Fun app tile linking to `https://centralschool.fun/MusicGen.html` for the public apps grid.

### Testing
- Ran `git diff --check` to ensure there are no whitespace or patch-format issues and it succeeded.
- Verified the new files `MusicGen.html` and `app/musicfun.html` were created and contain the expected iframe/embed code by inspecting their contents.
- Confirmed `index.html` and `public.html` include the new Music.Fun entries by checking the modified regions in the diffs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9de5f9c448321967a57bcfe637662)